### PR TITLE
Update aggregate_spectra.R

### DIFF
--- a/R/aggregate_spectra.R
+++ b/R/aggregate_spectra.R
@@ -114,7 +114,7 @@ setMethod("aggregate_spectra", "SpectraDataFrame",
         s <- s[, -(1:(length(id)))]
                 
         # new data slot
-        feat <- merge((features(obj)[, as.vector(id)]), (select_if(features(obj), is.numeric)), by="row.names")
+        feat <- merge(select(features(obj), as.vector(id)), (select_if(features(obj), is.numeric)), by="row.names",  suffixes = "")
         rownames(feat) <- feat[,1]
         feat <- feat[,-1]
         d <- ddply(feat, id, colwise(fun), .drop=TRUE, ...)

--- a/R/aggregate_spectra.R
+++ b/R/aggregate_spectra.R
@@ -114,7 +114,7 @@ setMethod("aggregate_spectra", "SpectraDataFrame",
         s <- s[, -(1:(length(id)))]
                 
         # new data slot
-        feat <- merge(select(features(obj), as.vector(id)), (select_if(features(obj), is.numeric)), by="row.names",  suffixes = "")
+        feat <- merge(subset(features(obj), select=c(id)), (select_if(features(obj), is.numeric)), by="row.names",  suffixes = "")
         rownames(feat) <- feat[,1]
         feat <- feat[,-1]
         d <- ddply(feat, id, colwise(fun), .drop=TRUE, ...)

--- a/R/aggregate_spectra.R
+++ b/R/aggregate_spectra.R
@@ -114,7 +114,7 @@ setMethod("aggregate_spectra", "SpectraDataFrame",
         s <- s[, -(1:(length(id)))]
                 
         # new data slot
-        feat <- merge(subset(features(obj), select=c(id)), (select_if(features(obj), is.numeric)), by="row.names",  suffixes = "")
+        feat <- merge(subset(features(obj), select=c(id)), Filter(is.numeric, features(obj)), by="row.names", suffixes = "")
         rownames(feat) <- feat[,1]
         feat <- feat[,-1]
         d <- ddply(feat, id, colwise(fun), .drop=TRUE, ...)


### PR DESCRIPTION
I tried to address the problems presented by aggregate_spectra in handling multiple columns in the data of the SpectralDataFrame objects.
With this modification, as soon as all the non-numeric columns are listed as "id", everything runs smoothly (tested for mean and median on the australia dataset and on my own dataset).
The only problem is that the following message is given. But the output has always been alright so far.
Warning message:
In if (id %in% names(features(obj))) { :
  the condition has length > 1 and only the first element will be used

This would be worth double checking since this is the first try I try programming in R!